### PR TITLE
🧪 Not assignable to type `NodeOptions`

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import express from "express"
 import { NODE_ENV, SENTRY_DSN } from "./env.js"
 
 const options: NodeOptions = {
-	dsn: SENTRY_DSN,
+	dsn: SENTRY_DSN.toString(),
 	environment: NODE_ENV,
 	integrations: [nodeProfilingIntegration()],
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,8 +1,8 @@
-import { loadEnv } from "./load_env.js"
+import { envInt, envUrl, loadEnv } from "./load_env.js"
 import type { NodeEnv } from "./node_env.js"
 
 const env = loadEnv()
 
-export const SENTRY_DSN: string | undefined = env["SENTRY_DSN"]
 export const NODE_ENV: NodeEnv = env.NODE_ENV
-export const PORT: number = Number(env["PORT"]) || 3000
+export const PORT: number = envInt("PORT")
+export const SENTRY_DSN: URL = envUrl("SENTRY_DSN")

--- a/src/load_env.ts
+++ b/src/load_env.ts
@@ -23,6 +23,26 @@ export function envNumber(key: string): number {
 	return num
 }
 
+export function envString(key: string): string {
+	const value = process.env[key]?.trim()
+	if (!value) throw new Error(`$${key} is missing`)
+	return value
+}
+
+export function envUrl(key: string, fallback?: URL): URL {
+	const value = process.env[key]?.trim()
+	if (fallback && !value) return fallback
+	if (!value) throw new Error(`$${key} is missing`)
+
+	const trimmed = value.endsWith("/") ? value.slice(0, -1) : value
+
+	try {
+		return new URL(trimmed)
+	} catch {
+		throw new Error(`$${key} is not a URL: ${value}`)
+	}
+}
+
 /** Loads environment variables from the `.env` files. `NODE_ENV` has to be set
  * in the environment and will not be picked up from there.
  *

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,7 +51,7 @@
 		"alwaysStrict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		// "exactOptionalPropertyTypes": true,
+		"exactOptionalPropertyTypes": true,
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
 		"noUncheckedIndexedAccess": true,


### PR DESCRIPTION
```sh
❯ pnpm build

> @natoboram/bug-report-sentry@0.0.0 build /home/nato/Code/github.com/NatoBoram/bug-report-sentry
> tsc

src/app.ts:8:7 - error TS2375: Type '{ dsn: string | undefined; environment: NodeEnv; integrations: Integration[]; tracesSampleRate: number; profilesSampleRate: number; }' is not assignable to type 'NodeOptions' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'dsn' are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.

8 const options: NodeOptions = {
        ~~~~~~~


Found 1 error in src/app.ts:8

 ELIFECYCLE  Command failed with exit code 2.
```